### PR TITLE
Issue 22 refactorize crit dec

### DIFF
--- a/steganogan/critics.py
+++ b/steganogan/critics.py
@@ -39,16 +39,16 @@ class BasicCritic(nn.Module):
 
     def __init__(self, hidden_size):
         super().__init__()
-        self.VERSION = '1'
+        self.version = '1'
         self.hidden_size = hidden_size
         self._models = self._build_models()
 
     def upgrade_legacy(self):
         """Transform legacy pretrained models to make them ussable with new code structure"""
         # Transform to version 1
-        if not hasattr(self, 'VERSION'):
+        if not hasattr(self, 'version'):
             self._models = self.layers
-            self.VERSION = '1'
+            self.version = '1'
 
     def forward(self, x):
         x = self._models(x)

--- a/steganogan/critics.py
+++ b/steganogan/critics.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import torch
-import torch.nn as nn
+from torch import nn
 
 
 class BasicCritic(nn.Module):
@@ -13,29 +13,45 @@ class BasicCritic(nn.Module):
     Output: (N, 1)
     """
 
-    def __init__(self, hidden_size):
-
-        super(BasicCritic, self).__init__()
-
-        self.layers = nn.Sequential(
-            nn.Conv2d(in_channels=3, out_channels=hidden_size, kernel_size=3),
-            nn.LeakyReLU(inplace=True),
-            nn.BatchNorm2d(hidden_size),
-
-            nn.Conv2d(in_channels=hidden_size, out_channels=hidden_size, kernel_size=3),
-            nn.LeakyReLU(inplace=True),
-            nn.BatchNorm2d(hidden_size),
-
-            nn.Conv2d(in_channels=hidden_size, out_channels=hidden_size, kernel_size=3),
-            nn.LeakyReLU(inplace=True),
-            nn.BatchNorm2d(hidden_size),
-
-            nn.Conv2d(in_channels=hidden_size, out_channels=1, kernel_size=3)
+    def _conv2d(self, in_channels, out_channels):
+        return nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=3
         )
 
-    def forward(self, x):
+    def _build_models(self):
+        return nn.Sequential(
+            self._conv2d(3, self.hidden_size),
+            nn.LeakyReLU(inplace=True),
+            nn.BatchNorm2d(self.hidden_size),
 
-        x = self.layers(x)
+            self._conv2d(self.hidden_size, self.hidden_size),
+            nn.LeakyReLU(inplace=True),
+            nn.BatchNorm2d(self.hidden_size),
+
+            self._conv2d(self.hidden_size, self.hidden_size),
+            nn.LeakyReLU(inplace=True),
+            nn.BatchNorm2d(self.hidden_size),
+
+            self._conv2d(self.hidden_size, 1)
+        )
+
+    def __init__(self, hidden_size):
+        super().__init__()
+        self.VERSION = '1'
+        self.hidden_size = hidden_size
+        self._models = self._build_models()
+
+    def upgrade_legacy(self):
+        """Transform legacy pretrained models to make them ussable with new code structure"""
+        # Transform to version 1
+        if not hasattr(self, 'VERSION'):
+            self._models = self.layers
+            self.VERSION = '1'
+
+    def forward(self, x):
+        x = self._models(x)
         x = torch.mean(x.view(x.size(0), -1), dim=1)
 
         return x

--- a/steganogan/critics.py
+++ b/steganogan/critics.py
@@ -44,7 +44,7 @@ class BasicCritic(nn.Module):
         self._models = self._build_models()
 
     def upgrade_legacy(self):
-        """Transform legacy pretrained models to make them ussable with new code structure"""
+        """Transform legacy pretrained models to make them usable with new code versions."""
         # Transform to version 1
         if not hasattr(self, 'version'):
             self._models = self.layers

--- a/steganogan/decoders.py
+++ b/steganogan/decoders.py
@@ -49,7 +49,7 @@ class BasicDecoder(nn.Module):
         self._models = self._build_models()
 
     def upgrade_legacy(self):
-        """Transform legacy pretrained models to make them ussable with new code structure"""
+        """Transform legacy pretrained models to make them usable with new code versions."""
         # Transform to version 1
         if not hasattr(self, 'version'):
             self._models = [self.layers]
@@ -100,7 +100,7 @@ class DenseDecoder(BasicDecoder):
         return self.conv1, self.conv2, self.conv3, self.conv4
 
     def upgrade_legacy(self):
-        """Transform legacy pretrained models to make them ussable with new code structure"""
+        """Transform legacy pretrained models to make them usable with new code versions."""
         # Transform to version 1
         if not hasattr(self, 'version'):
             self._models = [

--- a/steganogan/decoders.py
+++ b/steganogan/decoders.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import torch
-import torch.nn as nn
+from torch import nn
 
 
 class BasicDecoder(nn.Module):
@@ -13,33 +13,62 @@ class BasicDecoder(nn.Module):
     Output: (N, D, H, W)
     """
 
-    def __init__(self, data_depth, hidden_size):
-
-        super(BasicDecoder, self).__init__()
-
-        self.data_depth = data_depth
-
-        self.layers = nn.Sequential(
-            nn.Conv2d(in_channels=3, out_channels=hidden_size, kernel_size=3, padding=1),
-            nn.LeakyReLU(inplace=True),
-            nn.BatchNorm2d(hidden_size),
-
-            nn.Conv2d(in_channels=hidden_size, out_channels=hidden_size, kernel_size=3, padding=1),
-            nn.LeakyReLU(inplace=True),
-            nn.BatchNorm2d(hidden_size),
-
-            nn.Conv2d(in_channels=hidden_size, out_channels=hidden_size, kernel_size=3, padding=1),
-            nn.LeakyReLU(inplace=True),
-            nn.BatchNorm2d(hidden_size),
-
-            nn.Conv2d(in_channels=hidden_size, out_channels=data_depth, kernel_size=3, padding=1)
+    def _conv2d(self, in_channels, out_channels):
+        return nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=3,
+            padding=1
         )
 
+    def _build_models(self):
+        self.layers = nn.Sequential(
+            self._conv2d(3, self.hidden_size),
+            nn.LeakyReLU(inplace=True),
+            nn.BatchNorm2d(self.hidden_size),
+
+            self._conv2d(self.hidden_size, self.hidden_size),
+            nn.LeakyReLU(inplace=True),
+            nn.BatchNorm2d(self.hidden_size),
+
+            self._conv2d(self.hidden_size, self.hidden_size),
+            nn.LeakyReLU(inplace=True),
+            nn.BatchNorm2d(self.hidden_size),
+
+            self._conv2d(self.hidden_size, self.data_depth)
+        )
+
+        return [self.layers]
+
+    def __init__(self, data_depth, hidden_size):
+        super().__init__()
+        self.VERSION = '1'
+        self.data_depth = data_depth
+        self.hidden_size = hidden_size
+
+        self._models = self._build_models()
+
+    def upgrade_legacy(self):
+        """Transform legacy pretrained models to make them ussable with new code structure"""
+        # Transform to version 1
+        if not hasattr(self, 'VERSION'):
+            self._models = [self.layers]
+
+            self.VERSION = '1'
+
     def forward(self, x):
-        return self.layers(x)
+        x = self._models[0](x)
+
+        if len(self._models) > 1:
+            x_list = [x]
+            for layer in self._models[1:]:
+                x = layer(torch.cat(x_list, dim=1))
+                x_list.append(x)
+
+        return x
 
 
-class DenseDecoder(nn.Module):
+class DenseDecoder(BasicDecoder):
     """
     The DenseDecoder module takes an steganographic image and attempts to decode
     the embedded data tensor.
@@ -47,44 +76,38 @@ class DenseDecoder(nn.Module):
     Input: (N, 3, H, W)
     Output: (N, D, H, W)
     """
-
-    def __init__(self, data_depth, hidden_size):
-        super(DenseDecoder, self).__init__()
-        self.data_depth = data_depth
+    def _build_models(self):
         self.conv1 = nn.Sequential(
-            nn.Conv2d(in_channels=3,
-                      out_channels=hidden_size,
-                      kernel_size=3,
-                      padding=1),
+            self._conv2d(3, self.hidden_size),
             nn.LeakyReLU(inplace=True),
-            nn.BatchNorm2d(hidden_size),
-        )
-        self.conv2 = nn.Sequential(
-            nn.Conv2d(in_channels=hidden_size,
-                      out_channels=hidden_size,
-                      kernel_size=3,
-                      padding=1),
-            nn.LeakyReLU(inplace=True),
-            nn.BatchNorm2d(hidden_size),
-        )
-        self.conv3 = nn.Sequential(
-            nn.Conv2d(in_channels=hidden_size * 2,
-                      out_channels=hidden_size,
-                      kernel_size=3,
-                      padding=1),
-            nn.LeakyReLU(inplace=True),
-            nn.BatchNorm2d(hidden_size),
-        )
-        self.conv4 = nn.Sequential(
-            nn.Conv2d(in_channels=hidden_size * 3,
-                      out_channels=data_depth,
-                      kernel_size=3,
-                      padding=1),
+            nn.BatchNorm2d(self.hidden_size)
         )
 
-    def forward(self, x):
-        x1 = self.conv1(x)
-        x2 = self.conv2(x1)
-        x3 = self.conv3(torch.cat((x1, x2), dim=1))
-        x4 = self.conv4(torch.cat((x1, x2, x3), dim=1))
-        return x4
+        self.conv2 = nn.Sequential(
+            self._conv2d(self.hidden_size, self.hidden_size),
+            nn.LeakyReLU(inplace=True),
+            nn.BatchNorm2d(self.hidden_size)
+        )
+
+        self.conv3 = nn.Sequential(
+            self._conv2d(self.hidden_size * 2, self.hidden_size),
+            nn.LeakyReLU(inplace=True),
+            nn.BatchNorm2d(self.hidden_size)
+        )
+
+        self.conv4 = nn.Sequential(self._conv2d(self.hidden_size * 3, self.data_depth))
+
+        return self.conv1, self.conv2, self.conv3, self.conv4
+
+    def upgrade_legacy(self):
+        """Transform legacy pretrained models to make them ussable with new code structure"""
+        # Transform to version 1
+        if not hasattr(self, 'VERSION'):
+            self._models = [
+                self.conv1,
+                self.conv2,
+                self.conv3,
+                self.conv4
+            ]
+
+            self.VERSION = '1'

--- a/steganogan/decoders.py
+++ b/steganogan/decoders.py
@@ -42,7 +42,7 @@ class BasicDecoder(nn.Module):
 
     def __init__(self, data_depth, hidden_size):
         super().__init__()
-        self.VERSION = '1'
+        self.version = '1'
         self.data_depth = data_depth
         self.hidden_size = hidden_size
 
@@ -51,10 +51,10 @@ class BasicDecoder(nn.Module):
     def upgrade_legacy(self):
         """Transform legacy pretrained models to make them ussable with new code structure"""
         # Transform to version 1
-        if not hasattr(self, 'VERSION'):
+        if not hasattr(self, 'version'):
             self._models = [self.layers]
 
-            self.VERSION = '1'
+            self.version = '1'
 
     def forward(self, x):
         x = self._models[0](x)
@@ -102,7 +102,7 @@ class DenseDecoder(BasicDecoder):
     def upgrade_legacy(self):
         """Transform legacy pretrained models to make them ussable with new code structure"""
         # Transform to version 1
-        if not hasattr(self, 'VERSION'):
+        if not hasattr(self, 'version'):
             self._models = [
                 self.conv1,
                 self.conv2,
@@ -110,4 +110,4 @@ class DenseDecoder(BasicDecoder):
                 self.conv4
             ]
 
-            self.VERSION = '1'
+            self.version = '1'

--- a/steganogan/encoders.py
+++ b/steganogan/encoders.py
@@ -43,7 +43,7 @@ class BasicEncoder(nn.Module):
 
     def __init__(self, data_depth, hidden_size):
         super().__init__()
-        self.VERSION = '1'
+        self.version = '1'
         self.data_depth = data_depth
         self.hidden_size = hidden_size
         self._models = self._build_models()
@@ -51,8 +51,8 @@ class BasicEncoder(nn.Module):
     def upgrade_legacy(self):
         """Transform legacy pretrained models to make them ussable with new code structure"""
         # Transform to version 1
-        if not hasattr(self, 'VERSION'):
-            self.VERSION = '1'
+        if not hasattr(self, 'version'):
+            self.version = '1'
 
     def forward(self, image, data):
         x = self._models[0](image)

--- a/steganogan/encoders.py
+++ b/steganogan/encoders.py
@@ -49,7 +49,7 @@ class BasicEncoder(nn.Module):
         self._models = self._build_models()
 
     def upgrade_legacy(self):
-        """Transform legacy pretrained models to make them ussable with new code structure"""
+        """Transform legacy pretrained models to make them usable with new code versions."""
         # Transform to version 1
         if not hasattr(self, 'version'):
             self.version = '1'

--- a/steganogan/encoders.py
+++ b/steganogan/encoders.py
@@ -43,9 +43,16 @@ class BasicEncoder(nn.Module):
 
     def __init__(self, data_depth, hidden_size):
         super().__init__()
+        self.VERSION = '1'
         self.data_depth = data_depth
         self.hidden_size = hidden_size
         self._models = self._build_models()
+
+    def upgrade_legacy(self):
+        """Transform legacy pretrained models to make them ussable with new code structure"""
+        # Transform to version 1
+        if not hasattr(self, 'VERSION'):
+            self.VERSION = '1'
 
     def forward(self, image, data):
         x = self._models[0](image)

--- a/steganogan/models.py
+++ b/steganogan/models.py
@@ -346,5 +346,10 @@ class SteganoGAN(object):
         """Loads an instance of SteganoGAN from the given path."""
         steganogan = torch.load(path, map_location='cpu')
         steganogan.verbose = verbose
+
+        steganogan.encoder.upgrade_legacy()
+        steganogan.decoder.upgrade_legacy()
+        steganogan.critic.upgrade_legacy()
+
         steganogan.set_device(cuda)
         return steganogan

--- a/tests/test_critics.py
+++ b/tests/test_critics.py
@@ -8,6 +8,8 @@ import torch
 from steganogan import critics
 from tests.utils import assert_called_with_tensors
 
+import copy
+
 
 class TestBasicCritic(TestCase):
 
@@ -92,6 +94,6 @@ class TestBasicCritic(TestCase):
         self.test_critic.upgrade_legacy()
 
         # assert
-        assert self.test_critic.VERSION == expected_version
+        assert self.test_critic.version == expected_version
         assert self.test_critic._models == self.test_critic.layers
 

--- a/tests/test_critics.py
+++ b/tests/test_critics.py
@@ -84,7 +84,7 @@ class TestBasicCritic(TestCase):
         assert (result == expected).all()
         assert_called_with_tensors(layer1, [call_1])
 
-    def test_upgrade_legacy(self):
+    def test_upgrade_legacy_without_version(self):
         """Test that upgrade legacy works, must set _models to layers"""
         # setup
         self.test_critic.layers = Mock(return_value=torch.Tensor([[5, 6], [7, 8]]))
@@ -97,3 +97,15 @@ class TestBasicCritic(TestCase):
         assert self.test_critic.version == expected_version
         assert self.test_critic._models == self.test_critic.layers
 
+    @patch('steganogan.critics.nn.Sequential', autospec=True)
+    def test_upgrade_legacy_with_version_1(self, sequential_mock):
+        """The object must be the same and not changed by the method"""
+        # setup
+        critic = critics.BasicCritic(1)
+        expected = copy.deepcopy(critic)
+
+        # run
+        critic.upgrade_legacy()
+
+        # assert
+        assert critic.__dict__ == expected.__dict__

--- a/tests/test_critics.py
+++ b/tests/test_critics.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+
+from unittest import TestCase
+from unittest.mock import Mock, call, patch
+
+import torch
+
+from steganogan import critics
+from tests.utils import assert_called_with_tensors
+
+
+class TestBasicCritic(TestCase):
+
+    class TestCritic(critics.BasicCritic):
+        def __init__(self):
+            pass
+
+    def setUp(self):
+        self.test_critic = self.TestCritic()
+
+    @patch('steganogan.critics.nn.Conv2d', autospec=True)
+    def test__covn2d(self, conv2d_mock):
+        """Conv2d must be called with given args and kernel_size=3 and padding=1"""
+
+        # run
+        result = self.test_critic._conv2d(2, 4)
+
+        # asserts
+        assert result == conv2d_mock.return_value
+        conv2d_mock.assert_called_once_with(
+            in_channels=2,
+            out_channels=4,
+            kernel_size=3,
+        )
+
+    @patch('steganogan.critics.nn.Sequential')
+    @patch('steganogan.critics.nn.BatchNorm2d')
+    @patch('steganogan.critics.nn.Conv2d')
+    def test___init__(self, conv2d_mock, batchnorm2d_mock, sequential_mock):
+        """Test that conv2d and batchnorm are called when creating a new critic with hidden_size"""
+
+        # setup
+        hidden_size = 2
+
+        expected_conv2d_calls = [
+            call(in_channels=3, out_channels=2, kernel_size=3),
+            call(in_channels=2, out_channels=2, kernel_size=3),
+            call(in_channels=2, out_channels=2, kernel_size=3),
+            call(in_channels=2, out_channels=1, kernel_size=3)
+        ]
+
+        expected_batch_calls = [call(2), call(2), call(2)]
+
+        # run
+        critic = critics.BasicCritic(hidden_size)
+
+        # assert
+        assert conv2d_mock.call_args_list == expected_conv2d_calls
+        assert batchnorm2d_mock.call_args_list == expected_batch_calls
+
+    def test_forward(self):
+
+        """Test the return value of method forward"""
+        # setup
+        test_critic = self.TestCritic()
+
+        layer1 = Mock(return_value=torch.Tensor([[5, 6], [7, 8]]))
+        test_critic._models = layer1
+
+        image = torch.Tensor([[1, 2], [3, 4]])
+
+        call_1 = call(torch.Tensor([[1, 2], [3, 4]]))
+
+        expected = torch.Tensor([[5, 6], [7, 8]])
+
+        expected = torch.mean(expected.view(expected.size(0), -1), dim=1)
+
+        # run
+        result = test_critic.forward(image)
+
+        # assert
+        assert (result == expected).all()
+        assert_called_with_tensors(layer1, [call_1])
+
+    def test_upgrade_legacy(self):
+        """Test that upgrade legacy works, must set _models to layers"""
+        # setup
+        self.test_critic.layers = Mock(return_value=torch.Tensor([[5, 6], [7, 8]]))
+        expected_version = '1'
+
+        # run
+        self.test_critic.upgrade_legacy()
+
+        # assert
+        assert self.test_critic.VERSION == expected_version
+        assert self.test_critic._models == self.test_critic.layers
+

--- a/tests/test_critics.py
+++ b/tests/test_critics.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import copy
 from unittest import TestCase
 from unittest.mock import Mock, call, patch
 
@@ -7,8 +8,6 @@ import torch
 
 from steganogan import critics
 from tests.utils import assert_called_with_tensors
-
-import copy
 
 
 class TestBasicCritic(TestCase):
@@ -42,7 +41,7 @@ class TestBasicCritic(TestCase):
         """Test that conv2d and batchnorm are called when creating a new critic with hidden_size"""
 
         # run
-        critic = critics.BasicCritic(2)
+        critics.BasicCritic(2)
 
         # assert
         expected_batch_calls = [call(2), call(2), call(2)]

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+
+from unittest import TestCase
+from unittest.mock import Mock, call, patch
+
+import torch
+
+from steganogan import decoders
+from tests.utils import assert_called_with_tensors
+
+
+class TestBasicDecoder(TestCase):
+
+    class TestDecoder(decoders.BasicDecoder):
+        def __init__(self):
+            pass
+
+    def setUp(self):
+        self.test_decoder = self.TestDecoder()
+
+    @patch('steganogan.decoders.nn.Conv2d', autospec=True)
+    def test__covn2d(self, conv2d_mock):
+        """Conv2d must be called with given args and kernel_size=3 and padding=1"""
+
+        # run
+        result = self.test_decoder._conv2d(2, 4)
+
+        # asserts
+        assert result == conv2d_mock.return_value
+        conv2d_mock.assert_called_once_with(
+            in_channels=2,
+            out_channels=4,
+            kernel_size=3,
+            padding=1
+        )
+
+    @patch('steganogan.decoders.nn.Sequential')
+    @patch('steganogan.decoders.nn.Conv2d')
+    @patch('steganogan.decoders.nn.BatchNorm2d')
+    def test___init__(self, batchnorm_mock, conv2d_mock, sequential_mock):
+        """Test the init params and that the layers are created correctly"""
+        # setup
+        data_depth = 2
+        hidden_size = 5
+
+        expected_conv_calls = [
+            call(in_channels=3, out_channels=5, kernel_size=3, padding=1),
+            call(in_channels=5, out_channels=5, kernel_size=3, padding=1),
+            call(in_channels=5, out_channels=5, kernel_size=3, padding=1),
+            call(in_channels=5, out_channels=2, kernel_size=3, padding=1),
+        ]
+
+        expected_batch_calls = [call(5), call(5), call(5)]
+
+        # run
+
+        decoder = decoders.BasicDecoder(data_depth, hidden_size)
+
+        # assert
+        assert batchnorm_mock.call_args_list == expected_batch_calls
+        assert conv2d_mock.call_args_list == expected_conv_calls
+
+    def test_upgrade_legacy(self):
+        """Upgrade legacy must create self._models from conv1, conv2, conv3, conv4"""
+        # setup
+        self.test_decoder.layers = Mock(return_value=torch.Tensor([[5, 6], [7, 8]]))
+
+        expected_version = '1'
+
+        # run
+        self.test_decoder.upgrade_legacy()
+
+        # assert
+        assert self.test_decoder._models == [self.test_decoder.layers]
+        assert self.test_decoder.VERSION == expected_version
+
+    def test_forward_1_layer(self):
+        """If there is only one layer it must be called with image as the only argument."""
+        # setup
+        layer1 = Mock(return_value=torch.Tensor([[5, 6], [7, 8]]))
+        self.test_decoder._models = [layer1]
+
+        # run
+        image = torch.Tensor([[1, 2], [3, 4]])
+        result = self.test_decoder.forward(image)
+
+        call_1 = call(torch.Tensor([[1, 2], [3, 4]]))
+
+        # assert
+        assert (result == torch.Tensor([[5, 6], [7, 8]])).all()
+        assert_called_with_tensors(layer1, [call_1])
+
+    def test_forward_more_than_2_layers(self):
+        """If there are more than 2 layers, they must be called adding data to each result"""
+        # setup
+        layer1 = Mock(return_value=torch.Tensor([[5, 6], [7, 8]]))
+        layer2 = Mock(return_value=torch.Tensor([[9, 10], [11, 12]]))
+        layer3 = Mock(return_value=torch.Tensor([[13, 14], [15, 16]]))
+        self.test_decoder._models = [layer1, layer2, layer3]
+
+        # run
+        image = torch.Tensor([[1, 2], [3, 4]])
+        result = self.test_decoder.forward(image)
+
+        # asserts
+        call_layer_1 = call(torch.Tensor([[1, 2], [3, 4]]))
+        call_layer_2 = call(torch.Tensor([[5, 6], [7, 8]]))
+        call_layer_3 = call(torch.Tensor([[5, 6, 9, 10], [7, 8, 11, 12]]))
+
+        assert_called_with_tensors(layer1, [call_layer_1])
+        assert_called_with_tensors(layer2, [call_layer_2])
+        assert_called_with_tensors(layer3, [call_layer_3])
+
+        assert (result == torch.Tensor([[13, 14], [15, 16]])).all()
+
+
+class TestDenseDecoder(TestCase):
+
+    class TestDecoder(decoders.DenseDecoder):
+        def __init__(self):
+            pass
+
+    def test_upgrade_legacy(self):
+        """Upgrade legacy must create self._models from conv1, conv2, conv3, conv4"""
+        # setup
+        test_decoder = self.TestDecoder() # instance an empty decoder
+        test_decoder.conv1 = Mock(return_value=torch.Tensor([[5, 6], [7, 8]]))
+        test_decoder.conv2 = Mock(return_value=torch.Tensor([[9, 10], [11, 12]]))
+        test_decoder.conv3 = Mock(return_value=torch.Tensor([[13, 14], [15, 16]]))
+        test_decoder.conv4 = Mock(return_value=torch.Tensor([[17, 18], [19, 20]]))
+
+        expected_models = [
+            test_decoder.conv1,
+            test_decoder.conv2,
+            test_decoder.conv3,
+            test_decoder.conv4,
+        ]
+
+        expected_version = '1'
+
+        # run
+        test_decoder.upgrade_legacy()
+
+        # assert
+        assert test_decoder._models == expected_models
+        assert test_decoder.VERSION == expected_version
+
+
+    @patch('steganogan.decoders.nn.Sequential')
+    @patch('steganogan.decoders.nn.Conv2d')
+    @patch('steganogan.decoders.nn.BatchNorm2d')
+    def test___init__(self, batchnorm_mock, conv2d_mock, sequential_mock):
+        """Test the init params and that the layers are created correctly"""
+        # setup
+        data_depth = 2
+        hidden_size = 5
+
+        expected_conv_calls = [
+            call(in_channels=3, out_channels=5, kernel_size=3, padding=1),
+            call(in_channels=5, out_channels=5, kernel_size=3, padding=1),
+            call(in_channels=10, out_channels=5, kernel_size=3, padding=1),
+            call(in_channels=15, out_channels=2, kernel_size=3, padding=1),
+        ]
+
+        expected_batch_calls = [call(5), call(5), call(5)]
+
+        # run
+
+        decoder = decoders.DenseDecoder(data_depth, hidden_size)
+
+        # assert
+        assert batchnorm_mock.call_args_list == expected_batch_calls
+        assert conv2d_mock.call_args_list == expected_conv_calls

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -8,6 +8,8 @@ import torch
 from steganogan import decoders
 from tests.utils import assert_called_with_tensors
 
+import copy
+
 
 class TestBasicDecoder(TestCase):
 
@@ -60,7 +62,7 @@ class TestBasicDecoder(TestCase):
         assert batchnorm_mock.call_args_list == expected_batch_calls
         assert conv2d_mock.call_args_list == expected_conv_calls
 
-    def test_upgrade_legacy(self):
+    def test_upgrade_legacy_without_version(self):
         """Upgrade legacy must create self._models from conv1, conv2, conv3, conv4"""
         # setup
         self.test_decoder.layers = Mock(return_value=torch.Tensor([[5, 6], [7, 8]]))
@@ -72,7 +74,20 @@ class TestBasicDecoder(TestCase):
 
         # assert
         assert self.test_decoder._models == [self.test_decoder.layers]
-        assert self.test_decoder.VERSION == expected_version
+        assert self.test_decoder.version == expected_version
+
+    @patch('steganogan.decoders.nn.Sequential', autospec=True)
+    def test_upgrade_legacy_with_version_1(self, sequential_mock):
+        """The object must be the same and not changed by the method"""
+        # setup
+        decoder = decoders.BasicDecoder(1, 1)
+        expected = copy.deepcopy(decoder)
+
+        # run
+        decoder.upgrade_legacy()
+
+        # assert
+        assert decoder.__dict__ == expected.__dict__
 
     def test_forward_1_layer(self):
         """If there is only one layer it must be called with image as the only argument."""
@@ -120,7 +135,7 @@ class TestDenseDecoder(TestCase):
         def __init__(self):
             pass
 
-    def test_upgrade_legacy(self):
+    def test_upgrade_legacy_without_version(self):
         """Upgrade legacy must create self._models from conv1, conv2, conv3, conv4"""
         # setup
         test_decoder = self.TestDecoder() # instance an empty decoder
@@ -143,7 +158,20 @@ class TestDenseDecoder(TestCase):
 
         # assert
         assert test_decoder._models == expected_models
-        assert test_decoder.VERSION == expected_version
+        assert test_decoder.version == expected_version
+
+    @patch('steganogan.decoders.nn.Sequential', autospec=True)
+    def test_upgrade_legacy_with_version_1(self, sequential_mock):
+        """The object must be the same and not changed by the method"""
+        # setup
+        decoder = decoders.DenseDecoder(1, 1)
+        expected = copy.deepcopy(decoder)
+
+        # run
+        decoder.upgrade_legacy()
+
+        # assert
+        assert decoder.__dict__ == expected.__dict__
 
 
     @patch('steganogan.decoders.nn.Sequential')

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import copy
 from unittest import TestCase
 from unittest.mock import Mock, call, patch
 
@@ -7,8 +8,6 @@ import torch
 
 from steganogan import decoders
 from tests.utils import assert_called_with_tensors
-
-import copy
 
 
 class TestBasicDecoder(TestCase):
@@ -43,7 +42,7 @@ class TestBasicDecoder(TestCase):
         """Test the init params and that the layers are created correctly"""
 
         # run
-        decoder = decoders.BasicDecoder(2, 5)
+        decoders.BasicDecoder(2, 5)
 
         # assert
         expected_batch_calls = [call(5), call(5), call(5)]
@@ -136,7 +135,7 @@ class TestDenseDecoder(TestCase):
         """Upgrade legacy must create self._models from conv1, conv2, conv3, conv4"""
 
         # setup
-        test_decoder = self.TestDecoder() # instance an empty decoder
+        test_decoder = self.TestDecoder()  # instance an empty decoder
         test_decoder.conv1 = Mock(return_value=torch.Tensor([[5, 6], [7, 8]]))
         test_decoder.conv2 = Mock(return_value=torch.Tensor([[9, 10], [11, 12]]))
         test_decoder.conv3 = Mock(return_value=torch.Tensor([[13, 14], [15, 16]]))
@@ -176,7 +175,7 @@ class TestDenseDecoder(TestCase):
         """Test the init params and that the layers are created correctly"""
 
         # run
-        decoder = decoders.DenseDecoder(2, 5)
+        decoders.DenseDecoder(2, 5)
 
         # assert
         expected_batch_calls = [call(5), call(5), call(5)]

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -8,6 +8,8 @@ import torch
 from steganogan import encoders
 from tests.utils import assert_called_with_tensors
 
+import copy
+
 
 class TestBasicEncoder(TestCase):
 
@@ -34,7 +36,7 @@ class TestBasicEncoder(TestCase):
             padding=1
         )
 
-    def test_upgrade_legacy(self):
+    def test_upgrade_legacy_no_version(self):
         """Test that we set a version to our encoder for future code changes"""
         # setup
         expected_version = '1'
@@ -43,7 +45,20 @@ class TestBasicEncoder(TestCase):
         self.test_encoder.upgrade_legacy()
 
         # assert
-        assert self.test_encoder.VERSION == expected_version
+        assert self.test_encoder.version == expected_version
+
+    @patch('steganogan.encoders.nn.Sequential', autospec=True)
+    def test_upgrade_legacy_with_version_1(self, sequential_mock):
+        """The object must be the same and not changed by the method"""
+        # setup
+        encoder = encoders.BasicEncoder(1, 1)
+        expected = copy.deepcopy(encoder)
+
+        # run
+        encoder.upgrade_legacy()
+
+        # assert
+        assert encoder.__dict__ == expected.__dict__
 
     def test_forward_1_layer(self):
         """If there is only one layer it must be called with image as the only argument."""

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -38,18 +38,17 @@ class TestBasicEncoder(TestCase):
 
     def test_upgrade_legacy_no_version(self):
         """Test that we set a version to our encoder for future code changes"""
-        # setup
-        expected_version = '1'
 
         # run
         self.test_encoder.upgrade_legacy()
 
         # assert
-        assert self.test_encoder.version == expected_version
+        assert self.test_encoder.version == '1'
 
     @patch('steganogan.encoders.nn.Sequential', autospec=True)
     def test_upgrade_legacy_with_version_1(self, sequential_mock):
         """The object must be the same and not changed by the method"""
+
         # setup
         encoder = encoders.BasicEncoder(1, 1)
         expected = copy.deepcopy(encoder)
@@ -62,6 +61,7 @@ class TestBasicEncoder(TestCase):
 
     def test_forward_1_layer(self):
         """If there is only one layer it must be called with image as the only argument."""
+
         # setup
         layer1 = Mock(return_value=torch.Tensor([[5, 6], [7, 8]]))
         self.test_encoder._models = [layer1]
@@ -70,14 +70,15 @@ class TestBasicEncoder(TestCase):
         image = torch.Tensor([[1, 2], [3, 4]])
         result = self.test_encoder.forward(image, 'some_data')
 
-        call_1 = call(torch.Tensor([[1, 2], [3, 4]]))
-
         # assert
         assert (result == torch.Tensor([[5, 6], [7, 8]])).all()
+
+        call_1 = call(torch.Tensor([[1, 2], [3, 4]]))
         assert_called_with_tensors(layer1, [call_1])
 
     def test_forward_more_than_2_layers(self):
         """If there are more than 2 layers, they must be called adding data to each result"""
+
         # setup
         layer1 = Mock(return_value=torch.Tensor([[5, 6], [7, 8]]))
         layer2 = Mock(return_value=torch.Tensor([[9, 10], [11, 12]]))
@@ -102,6 +103,7 @@ class TestBasicEncoder(TestCase):
 
     def test_forward_add_image(self):
         """If add_image is true, image must be added to the result."""
+
         # setup
         self.test_encoder.add_image = True
         layer1 = Mock(return_value=torch.Tensor([[5, 6], [7, 8]]))
@@ -153,6 +155,7 @@ class TestResidualEncoder(TestCase):
 
     def test_forward_1_layer(self):
         """If there is only one layer it must be called with image as the only argument."""
+
         # setup
         layer1 = Mock(return_value=torch.Tensor([[5, 6], [7, 8]]))
         self.test_encoder._models = [layer1]
@@ -161,14 +164,15 @@ class TestResidualEncoder(TestCase):
         image = torch.Tensor([[1, 2], [3, 4]])
         result = self.test_encoder.forward(image, 'some_data')
 
-        call_1 = call(torch.Tensor([[1, 2], [3, 4]]))
-
         # assert
         assert (result == torch.Tensor([[6, 8], [10, 12]])).all()
+
+        call_1 = call(torch.Tensor([[1, 2], [3, 4]]))
         assert_called_with_tensors(layer1, [call_1])
 
     def test_forward_more_than_2_layers(self):
         """If there are more than 2 layers, they must be called adding data to each result"""
+
         # setup
         layer1 = Mock(return_value=torch.Tensor([[5, 6], [7, 8]]))
         layer2 = Mock(return_value=torch.Tensor([[9, 10], [11, 12]]))
@@ -220,6 +224,7 @@ class TestDenseEncoder(TestCase):
 
     def test_forward_1_layer(self):
         """If there is only one layer it must be called with image as the only argument."""
+
         # setup
         layer1 = Mock(return_value=torch.Tensor([[5, 6], [7, 8]]))
         self.test_encoder._models = [layer1]
@@ -228,14 +233,15 @@ class TestDenseEncoder(TestCase):
         image = torch.Tensor([[1, 2], [3, 4]])
         result = self.test_encoder.forward(image, 'some_data')
 
-        call_1 = call(torch.Tensor([[1, 2], [3, 4]]))
-
         # assert
         assert (result == torch.Tensor([[6, 8], [10, 12]])).all()
+
+        call_1 = call(torch.Tensor([[1, 2], [3, 4]]))
         assert_called_with_tensors(layer1, [call_1])
 
     def test_forward_more_than_2_layers(self):
         """If there are more than 2 layers, they must be called adding data to each result"""
+
         # setup
         layer1 = Mock(return_value=torch.Tensor([[5, 6], [7, 8]]))
         layer2 = Mock(return_value=torch.Tensor([[9, 10], [11, 12]]))

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import copy
 from unittest import TestCase
 from unittest.mock import Mock, call, patch
 
@@ -7,8 +8,6 @@ import torch
 
 from steganogan import encoders
 from tests.utils import assert_called_with_tensors
-
-import copy
 
 
 class TestBasicEncoder(TestCase):

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -34,6 +34,17 @@ class TestBasicEncoder(TestCase):
             padding=1
         )
 
+    def test_upgrade_legacy(self):
+        """Test that we set a version to our encoder for future code changes"""
+        # setup
+        expected_version = '1'
+
+        # run
+        self.test_encoder.upgrade_legacy()
+
+        # assert
+        assert self.test_encoder.VERSION == expected_version
+
     def test_forward_1_layer(self):
         """If there is only one layer it must be called with image as the only argument."""
         # setup


### PR DESCRIPTION
Critics and Decoders refactor to a new way so we can reuse the code in the future with inheritance. Created methods to use old (legacy) critics, decoders and encoders.
Added version to the architectures and created unit tests.
Resolves #22 