### PR TITLE
Trained models are not currently compatible with reedsolo>0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('HISTORY.md') as history_file:
 
 install_requires = [
     'imageio>=2.4.1',
-    'reedsolo>=0.3',
+    'reedsolo<=0.3',
     'scipy>=1.1.0',
     'torch==1.0.0',
     'torchvision==0.2.1',

--- a/steganogan/utils.py
+++ b/steganogan/utils.py
@@ -53,7 +53,7 @@ def text_to_bytearray(text):
 def bytearray_to_text(x):
     """Apply error correction and decompress"""
     try:
-        text, _, _ = rs.decode(x)
+        text = rs.decode(x)
         text = zlib.decompress(text)
         return text.decode("utf-8")
     except BaseException:


### PR DESCRIPTION
Our previous models are not compatible with the new update to this package. We must inspect this further --> but for now, I suggest a revert to reedsolo <= 0.3